### PR TITLE
Correct the path of MFTracing.xml to fix unspecific error

### DIFF
--- a/Scripts/TraceLogging/EnableTraceLogs.cmd
+++ b/Scripts/TraceLogging/EnableTraceLogs.cmd
@@ -60,6 +60,6 @@ logman import sds_log -xml .\Config\sds_log.xml -ets
 logman import NGCTPMFingerprintCP -xml .\Config\NGCTPMFingerprintCP.xml -ets
 logman import LogonUICredFrame -xml .\Config\LogonUICredFrame.xml -ets
 logman import WinBioService -xml .\Config\WinBioService.xml -ets
-logman import MFTracing -xml MFTracing.xml -ets
+logman import MFTracing -xml .\Config\MFTracing.xml -ets
 
 echo.

--- a/Scripts/TraceLogging/EnableTraceLogsNoRestart.cmd
+++ b/Scripts/TraceLogging/EnableTraceLogsNoRestart.cmd
@@ -60,6 +60,6 @@ logman import sds_log -xml .\Config\sds_log.xml -ets
 logman import NGCTPMFingerprintCP -xml .\Config\NGCTPMFingerprintCP.xml -ets
 logman import LogonUICredFrame -xml .\Config\LogonUICredFrame.xml -ets
 logman import WinBioService -xml .\Config\WinBioService.xml -ets
-logman import MFTracing -xml MFTracing.xml -ets
+logman import MFTracing -xml .\Config\MFTracing.xml -ets
 
 echo.


### PR DESCRIPTION
Reason:
We will receive unspecific error when run this command: `logman import MFTracing -xml MFTracing.xml -ets`.
The reason is MFTracing.xml is placed under `.\Config\` so we cannot find MFTracing.xml in original command.