### PR TITLE
Add IQCaputre log

### DIFF
--- a/Scripts/TraceLogging/CopyEtlLogs.cmd
+++ b/Scripts/TraceLogging/CopyEtlLogs.cmd
@@ -44,6 +44,7 @@ logman stop LogonUICredFrame -ets >nul 2>&1
 logman stop WinBioService -ets >nul 2>&1
 logman stop MFTracing -ets >nul 2>&1
 logman stop KernelPnP -ets >nul 2>&1
+logman stop FaceIQCapture -ets >nul 2>&1
 
 REM sleep for 2 seconds
 ping 127.0.0.1 -n 10 -w 200 > nul 2>&1
@@ -69,6 +70,7 @@ copy "%WINDIR%\system32\LogFiles\WMI\LogonUICredFrame.*" "%OUTPUT_FOLDER%"\
 copy "%WINDIR%\system32\LogFiles\WMI\WinBioService.*" "%OUTPUT_FOLDER%"\
 copy "%WINDIR%\system32\LogFiles\WMI\MFTracing.*" "%OUTPUT_FOLDER%"\
 copy "%WINDIR%\system32\LogFiles\WMI\KernelPnP.*" "%OUTPUT_FOLDER%"\
+copy "%WINDIR%\system32\LogFiles\WMI\IQCapture.*" "%OUTPUT_FOLDER%"\
 copy "%WINDIR%\Analog\Providers\ProviderLogOutput.txt" "%OUTPUT_FOLDER%"\ >nul 2>&1
 copy "%HOMEDRIVE%\credprovs.*" "%OUTPUT_FOLDER%"\
 
@@ -85,6 +87,7 @@ del %WINDIR%\System32\LogFiles\WMI\LogonUICredFrame.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\WinBioService.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\MFTracing.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\KernelPnP.etl* >nul 2>&1
+del %WINDIR%\System32\LogFiles\WMI\IQCapture.etl* >nul 2>&1
 del %HOMEDRIVE%\credprovs.reg* >nul 2>&1
 
 echo.

--- a/Scripts/TraceLogging/DisableTraceLogs.cmd
+++ b/Scripts/TraceLogging/DisableTraceLogs.cmd
@@ -20,6 +20,8 @@ logman stop NGCTPMFingerprintCP -ets >nul 2>&1
 logman stop LogonUICredFrame -ets >nul 2>&1
 logman stop WinBioService -ets >nul 2>&1
 logman stop MFTracing -ets >nul 2>&1
+logman stop KernelPnP -ets >nul 2>&1
+logman stop FaceIQCapture -ets >nul 2>&1
 
 del %WINDIR%\System32\LogFiles\WMI\FaceUnlock.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\FaceReco.etl* >nul 2>&1
@@ -32,6 +34,8 @@ del %WINDIR%\System32\LogFiles\WMI\NGCTPMFingerprintCP.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\LogonUICredFrame.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\WinBioService.etl* >nul 2>&1
 del %WINDIR%\System32\LogFiles\WMI\MFTracing.etl* >nul 2>&1
+del %WINDIR%\System32\LogFiles\WMI\KernelPnP.etl* >nul 2>&1
+del %WINDIR%\System32\LogFiles\WMI\IQCapture.etl* >nul 2>&1
 
 reg import .\Config\DisableAllLoggers.reg
 

--- a/Scripts/TraceLogging/EnableTraceLogs.cmd
+++ b/Scripts/TraceLogging/EnableTraceLogs.cmd
@@ -64,5 +64,6 @@ logman import LogonUICredFrame -xml .\Config\LogonUICredFrame.xml -ets
 logman import WinBioService -xml .\Config\WinBioService.xml -ets
 logman import MFTracing -xml .\Config\MFTracing.xml -ets
 logman import KernelPnP -xml .\Config\KernelPnP.xml -ets
+logman create trace FaceIQCapture -p {4be6892c-cb5e-5dd9-d5e4-21d00f52c620} 0xFFFFFFFF 5 -o %WINDIR%\system32\LogFiles\WMI\IQCapture.etl -ets
 
 echo.


### PR DESCRIPTION
IQCapture starts to use the Windows tracelog since version 3.2.5.1.

1. This PR added IQCapture provider to the trace log. There's no need to enable regkey/xml because IQCapture doesn't support the reboot scenario.
2. Added the missing KernelPnP in DisableTraceLogs.cmd.

